### PR TITLE
fix typo that causes error on init

### DIFF
--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -33,8 +33,9 @@ variable "s3_bucket" {
 # optional
 
 variable "apps_folder" {
-  type        = "apps/"
+  type        = string
   description = "Folder where apps are stored, must end with /."
+  default     = "apps/"
 }
 
 variable "tags" {


### PR DESCRIPTION
error message

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/59336383/229766924-928e9179-db57-42d0-97cd-59efb230b378.png">
